### PR TITLE
Implementation of no-overwrite header for upload operation

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -23,6 +23,7 @@ from awscli.compat import ensure_text_type, queue
 from awscli.customizations.s3.subscribers import OnDoneFilteredSubscriber
 from awscli.customizations.s3.utils import WarningResult, human_readable_size
 from awscli.customizations.utils import uni_print
+from awscli.customizations.s3.utils import create_warning
 
 LOGGER = logging.getLogger(__name__)
 
@@ -109,6 +110,7 @@ class ProgressResultSubscriber(BaseResultSubscriber):
 
 class DoneResultSubscriber(BaseResultSubscriber, OnDoneFilteredSubscriber):
     def _on_success(self, future):
+        
         self._result_queue.put(
             SuccessResult(
                 transfer_type=self._transfer_type,
@@ -124,6 +126,11 @@ class DoneResultSubscriber(BaseResultSubscriber, OnDoneFilteredSubscriber):
                 error_result_cls = ErrorResult
             self._result_queue.put(error_result_cls(exception=e))
         else:
+            if self._is_precondition_failed(e):
+                error_message = f"as it already exists on {self._dest}"
+                warning = create_warning(self._src, error_message, True)
+                self._result_queue.put(warning)
+                return 
             self._result_queue.put(
                 FailureResult(
                     transfer_type=self._transfer_type,
@@ -132,6 +139,11 @@ class DoneResultSubscriber(BaseResultSubscriber, OnDoneFilteredSubscriber):
                     exception=e,
                 )
             )
+    
+    def _is_precondition_failed(self, exception):
+        """Check if this is a PreconditionFailed error"""
+        return (hasattr(exception, 'response') and 
+            exception.response.get('Error', {}).get('Code') == 'PreconditionFailed')
 
 
 class BaseResultHandler:

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1467,7 +1467,6 @@ class CommandArchitecture:
         # tasks will give a 2 RC.  Otherwise a RC of zero is returned.
         rc = 0
         if files[0].num_tasks_failed > 0:
-            LOGGER.debug("Number of tasks failed: %s", files[0].num_tasks_failed)
             rc = 1
         elif files[0].num_tasks_warned > 0:
             rc = 2

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -642,6 +642,15 @@ BUCKET_REGION = {
     ),
 }
 
+NO_OVERWRITE = {
+    'name': 'no-overwrite',
+    'action': 'store_true',
+    'help_text': (
+        "To only upload files that don't exist at the destination"
+    ),
+
+}
+
 TRANSFER_ARGS = [
     DRYRUN,
     QUIET,
@@ -1057,7 +1066,7 @@ class CpCommand(S3TransferCommand):
             }
         ]
         + TRANSFER_ARGS
-        + [METADATA, COPY_PROPS, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE]
+        + [METADATA, COPY_PROPS, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE, NO_OVERWRITE]
     )
 
 
@@ -1081,6 +1090,7 @@ class MvCommand(S3TransferCommand):
             METADATA_DIRECTIVE,
             RECURSIVE,
             VALIDATE_SAME_S3_PATHS,
+            NO_OVERWRITE,
         ]
     )
 
@@ -1336,6 +1346,7 @@ class CommandArchitecture:
         }
         result_queue = queue.Queue()
         operation_name = cmd_translation[paths_type]
+        LOGGER.debug("OPERATION TYPE %s",operation_name)
 
         fgen_kwargs = {
             'client': self._source_client,
@@ -1456,6 +1467,7 @@ class CommandArchitecture:
         # tasks will give a 2 RC.  Otherwise a RC of zero is returned.
         rc = 0
         if files[0].num_tasks_failed > 0:
+            LOGGER.debug("Number of tasks failed: %s", files[0].num_tasks_failed)
             rc = 1
         elif files[0].num_tasks_warned > 0:
             rc = 2

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -489,6 +489,7 @@ class RequestParamsMapper:
         cls._set_sse_c_request_params(request_params, cli_params)
         cls._set_request_payer_param(request_params, cli_params)
         cls._set_checksum_algorithm_param(request_params, cli_params)
+        cls._set_no_overwrite_param(request_params, cli_params)
 
     @classmethod
     def map_get_object_params(cls, request_params, cli_params):
@@ -557,6 +558,12 @@ class RequestParamsMapper:
     @classmethod
     def map_list_objects_v2_params(cls, request_params, cli_params):
         cls._set_request_payer_param(request_params, cli_params)
+    
+    @classmethod
+    def _set_no_overwrite_param(cls, request_params, cli_params):
+        """Mapping No overwrite header with IfNoneMatch"""
+        if cli_params.get('no_overwrite'):
+            request_params['IfNoneMatch'] = "*"
 
     @classmethod
     def _set_request_payer_param(cls, request_params, cli_params):

--- a/awscli/s3transfer/manager.py
+++ b/awscli/s3transfer/manager.py
@@ -195,6 +195,7 @@ class TransferManager:
         + [
             'ChecksumType',
             'MpuObjectSize',
+            'IfNoneMatch',
         ]
         + FULL_OBJECT_CHECKSUM_ARGS
     )
@@ -522,6 +523,7 @@ class TransferManager:
         ):
             set_default_checksum_algorithm(extra_args)
 
+    # Potential
     def _submit_transfer(
         self, call_args, submission_task_cls, extra_main_kwargs=None
     ):

--- a/awscli/s3transfer/upload.py
+++ b/awscli/s3transfer/upload.py
@@ -515,7 +515,7 @@ class UploadSubmissionTask(SubmissionTask):
 
     PUT_OBJECT_BLOCKLIST = ["ChecksumType", "MpuObjectSize"]
 
-    CREATE_MULTIPART_BLOCKLIST = FULL_OBJECT_CHECKSUM_ARGS + ["MpuObjectSize"]
+    CREATE_MULTIPART_BLOCKLIST = FULL_OBJECT_CHECKSUM_ARGS + ["MpuObjectSize", "IfNoneMatch"]
 
     UPLOAD_PART_ARGS = [
         'ChecksumAlgorithm',

--- a/awscli/s3transfer/upload.py
+++ b/awscli/s3transfer/upload.py
@@ -534,6 +534,7 @@ class UploadSubmissionTask(SubmissionTask):
         'ExpectedBucketOwner',
         'ChecksumType',
         'MpuObjectSize',
+        'IfNoneMatch',
     ] + FULL_OBJECT_CHECKSUM_ARGS
 
     def _get_upload_input_manager_cls(self, transfer_future):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -295,6 +295,69 @@ class TestCPCommand(BaseCPCommandTest):
             len(self.operations_called), 1, self.operations_called
         )
         self.assertEqual(self.operations_called[0][0].name, 'ListObjectsV2')
+    
+    def test_no_overwrite_flag_when_object_not_exists_on_target(self):
+        """Test when object with different key is successsfully uploaded using no-overwrite"""
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt --no-overwrite' % ( self.prefix,full_path)
+        self.parsed_responses = [
+            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        #Verify putObject was called
+        self.assertEqual(
+            len(self.operations_called), 1, self.operations_called
+        )
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        # Verify the IfNoneMatch condition was set in the request
+        self.assertEqual(self.operations_called[0][1]['IfNoneMatch'], '*')
+    
+    def test_no_overwrite_flag_when_object_exists_on_target(self):
+        """Test warning message when object already exists using no-overwrite"""
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt --no-overwrite' % ( self.prefix,full_path)
+        # Set up the response to simulate a PreconditionFailed error
+        self.http_response.status_code = 412
+        self.parsed_responses = [
+            {
+                'Error': {
+                    'Code': 'PreconditionFailed',
+                    'Message': 'At least one of the pre-conditions you specified did not hold'
+                }
+            }
+        ]
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=2) #Checking for warning
+        # Verify PutObject was attempted with IfNoneMatch
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        self.assertEqual(self.operations_called[0][1]['IfNoneMatch'], '*')
+
+    def test_no_overwrite_flag_multipart_upload_when_object_not_exists_on_target(self):
+        """Test multipart upload with no-overwrite flag when object doesn't exist"""
+        # Create a large file that will trigger multipart upload
+        full_path = self.files.create_file('foo.txt', 'a' * 10 * (1024**2))
+        cmdline = '%s %s s3://bucket/key.txt --no-overwrite' % (self.prefix, full_path)
+    
+        # Set up responses for multipart upload
+        self.parsed_responses = [
+            {'UploadId': 'foo'},  # CreateMultipartUpload response
+            {'ETag': '"foo-1"'},  # UploadPart response
+            {'ETag': '"foo-2"'},  # UploadPart response
+            {}                    # CompleteMultipartUpload response
+        ]
+    
+        self.run_cmd(cmdline, expected_rc=0)
+    
+        # Verify all multipart operations were called
+        self.assertEqual(len(self.operations_called), 4)
+        self.assertEqual(self.operations_called[0][0].name, 'CreateMultipartUpload')
+        self.assertEqual(self.operations_called[1][0].name, 'UploadPart')
+        self.assertEqual(self.operations_called[2][0].name, 'UploadPart')
+        self.assertEqual(self.operations_called[3][0].name, 'CompleteMultipartUpload')
+    
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[3][1]['IfNoneMatch'], '*')
+
 
     def test_dryrun_download(self):
         self.parsed_responses = [self.head_object_response()]


### PR DESCRIPTION
**Summary**

Customer requested a feature to prevent overwriting of objects when a object with same key is uploaded to S3 bucket from their local storage. This PR solves this issue for `cp` command prevent user to upload objects with same key on S3 bucket.

** Description**

Customers requested to prevent of overwriting of objects. This is done by providing `no-overwrite` header  usinfg`ifNoneMatch` feature of Amazon S3 which only allows to upload objects that are not present on the bucket. This header also supports multi-part upload as well as work well with other `cp` header. 
If the user tries to upload the file which is already present at the target bucket, the controller will show a warning about `skipping the file`.

Test cases are also written to check for multipart upload as well as for single upload where both scenarios are considered one when file is present at destination and other when it is not present.

